### PR TITLE
docs(core): Fix stray comments, add package doc, clarify contracts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Contributors to invoke
+Copyright (c) 2026 Contributors to pipeline
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/async_observer.go
+++ b/async_observer.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DefaultAsyncObserverBuffer is the recommended queue size for
-// [NewAsyncObserver] apropos nothing.
+// [NewAsyncObserver].
 const DefaultAsyncObserverBuffer = 256
 
 // AsyncObserver wraps an [Observer] and processes events in a background

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,16 @@
+// Package pipeline provides observable task pipelines: define stages and
+// steps, and an [Executor] handles sequencing, parallelism and flow control
+// while emitting structured events to registered [Observer] implementations.
+//
+// The package separates three concerns:
+//
+//   - Definition: [Pipeline], [Stage] and [Step] describe the work, built
+//     via [NewPipeline], [NewStage], [NewParallelStage] and [NewStep].
+//   - Execution: [Executor.Run] validates and runs the pipeline, applying
+//     conditions, sentinel flow control ([ErrSkipStage], [ErrSkipPipeline])
+//     and per-step middleware ([WithRetry], [WithTimeout]).
+//   - Observation: every lifecycle transition and in-flight signal is
+//     delivered as an [Event] to observers, decoupling execution from
+//     presentation. Ready-made observers live in the observers/ submodules,
+//     and steps emit their own events via the EmitX helpers.
+package pipeline

--- a/event.go
+++ b/event.go
@@ -7,6 +7,11 @@ import (
 
 // Observer receives events emitted during pipeline execution. OnEvent is called
 // synchronously from within the executor.
+//
+// The executor serialises OnEvent calls, including events emitted by
+// concurrently running parallel steps, so an observer needs no internal
+// locking unless it is shared between executors or otherwise invoked from
+// multiple sources.
 type Observer interface {
 	OnEvent(ctx context.Context, event Event)
 }
@@ -42,6 +47,11 @@ func (l Location) WithStep(name string) Location {
 }
 
 // BaseEvent carries the fields common to every event.
+//
+// The struct tags on events exist for callers that marshal them directly,
+// but error fields are excluded (`json:"-"`) because Go serialises the error
+// interface as "{}". The observers/json envelope is the supported JSON
+// serialisation; it carries errors as strings.
 type BaseEvent struct {
 	Location
 

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -6,8 +6,12 @@ import (
 )
 
 // WithTimeout wraps a [StepFn] with a per-step deadline. If the step does not
-// complete within d, the context is cancelled and the step receives
-// [context.DeadlineExceeded].
+// complete within d, its context is cancelled with [context.DeadlineExceeded].
+//
+// Enforcement is cooperative: the wrapper cannot interrupt a step that
+// ignores its context, so such a step will overrun the deadline. Steps must
+// honour ctx cancellation (as any long-running work should) for the timeout
+// to take effect.
 //
 //	pipeline.Step{
 //	    Name: "deploy",

--- a/observers/plain/observer.go
+++ b/observers/plain/observer.go
@@ -29,7 +29,7 @@ type Observer struct {
 	starts map[pipeline.Location]time.Time
 }
 
-// New creates a terminal observer that writes to w.
+// New creates a plain-text observer that writes to w.
 func New(w io.Writer) *Observer {
 	return &Observer{
 		w:      w,


### PR DESCRIPTION
- Remove leftover "apropos nothing" phrase; fix plain observer's copy-pasted doc
- Add a package doc comment (`doc.go`) so pkg.go.dev shows an overview
- Document that `WithTimeout` enforcement is cooperative, that the executor serialises `OnEvent` calls, and that the json observer envelope is the supported event serialisation
- Fix leftover project name in LICENSE