### PR TITLE
fix(core): Preserve final attempt error when retry is cancelled

### DIFF
--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -17,7 +17,8 @@ import (
 //	}
 //
 // If the context is cancelled between attempts, the retry loop stops and
-// returns the context error. Panics if maxAttempts < 1.
+// returns the context error joined with the final attempt's error, so the
+// underlying failure is not lost. Panics if maxAttempts < 1.
 func WithRetry(maxAttempts int, backoff time.Duration, fn StepFn) StepFn {
 	if maxAttempts < 1 {
 		panic("pipeline: WithRetry maxAttempts must be >= 1")
@@ -49,7 +50,8 @@ func WithRetry(maxAttempts int, backoff time.Duration, fn StepFn) StepFn {
 			case <-ctx.Done():
 				timer.Stop()
 
-				return ctx.Err()
+				// Keep the attempt's error visible alongside the cancellation.
+				return errors.Join(err, ctx.Err())
 			case <-timer.C:
 			}
 		}

--- a/middleware_retry_test.go
+++ b/middleware_retry_test.go
@@ -60,17 +60,20 @@ func TestWithRetry_RespectsContextCancellation(t *testing.T) {
 
 	var attempts atomic.Int32
 
+	attemptErr := errors.New("fail")
+
 	step := pipeline.WithRetry(10, time.Second, func(_ context.Context) error {
 		if attempts.Add(1) == 1 {
 			cancel()
 		}
 
-		return errors.New("fail")
+		return attemptErr
 	})
 
 	err := step(ctx)
 
 	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, attemptErr, "final attempt's error should be preserved")
 	assert.Equal(t, int32(1), attempts.Load())
 }
 


### PR DESCRIPTION
`WithRetry` returned a bare `ctx.Err()` when cancelled during backoff, discarding the last attempt's actual failure. Now returns `errors.Join(err, ctx.Err())` so both remain matchable with `errors.Is`.