### PR TITLE
build(terminal): Require published core version instead of local replace

### DIFF
--- a/observers/terminal/go.mod
+++ b/observers/terminal/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/ruffel/pipeline v0.0.0-00010101000000-000000000000
+	github.com/ruffel/pipeline v0.1.4
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -26,5 +26,3 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/ruffel/pipeline => ../..

--- a/observers/terminal/go.sum
+++ b/observers/terminal/go.sum
@@ -25,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/ruffel/pipeline v0.1.4 h1:hZbzv6BG9W5avG/yHmRSsvuaQkh0GDTH/sZWA8gIk18=
+github.com/ruffel/pipeline v0.1.4/go.mod h1:HyRGTOcnhM01wXvUs3+T3fgPZPtlNbjz9XHFoEeiFUw=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
Consumers ignore `replace` directives in a dependency's go.mod, so `go get github.com/ruffel/pipeline/observers/terminal` fails standalone: it resolves the placeholder `v0.0.0-00010101000000-000000000000` require, which doesn't exist (`invalid version: unknown revision 000000000000`). It only worked when the consumer also required the root module, letting MVS select a real version.

Require the latest published core (`v0.1.4`) instead; local development is unaffected because `go.work` already wires the workspace. Release flow now needs the require bumped per release — guard added separately.