### PR TITLE
ci(github): Lint terminal module, build examples, guard release requires

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,49 @@ jobs:
           version: "v2.8.0"
           args: --timeout=5m
 
+      # Workspace stays on so the submodule typechecks against HEAD core.
+      - name: golangci-lint (observers/terminal)
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: "v2.8.0"
+          args: --timeout=5m
+          working-directory: observers/terminal
+
       - name: Verify Clean State
         run: just check-clean
 
       - name: Run Unit Tests (Common)
         run: just test
+
+      - name: Build Examples
+        run: just build-examples
+
+  govulncheck:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.0"
+          check-latest: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Scan root module
+        run: govulncheck ./...
+
+      - name: Scan observers/terminal
+        working-directory: observers/terminal
+        run: govulncheck ./...
 
   api-compatibility:
     name: API Compatibility

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,29 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.0"
+          check-latest: true
+
+      # Submodule tags share the release commit, so each submodule must
+      # require the core version being tagged — otherwise standalone
+      # installs resolve a stale (or missing) core API.
+      - name: Verify submodule requires match release
+        env:
+          MODULES: observers/terminal
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+
+          for mod in ${MODULES}; do
+            REQ="$(cd "${mod}" && go mod edit -json | jq -r '.Require[] | select(.Path == "github.com/ruffel/pipeline") | .Version')"
+
+            if [ "${REQ}" != "${VERSION}" ]; then
+              echo "::error::${mod}/go.mod requires github.com/ruffel/pipeline ${REQ}, expected ${VERSION}. Run 'just prepare-release ${VERSION}' and merge before releasing."
+              exit 1
+            fi
+          done
+
       - name: Tag submodules
         env:
           MODULES: observers/terminal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+## Setup
+
+Requires Go 1.25+, [just](https://github.com/casey/just), and
+[golangci-lint](https://golangci-lint.run) (version pinned in CI).
+
+The repo is a Go workspace: the core module at the root, `observers/terminal`
+as a submodule, and the examples as standalone modules.
+
+## Workflow
+
+```bash
+just            # test + lint everything
+just check-clean # fmt + tidy must leave no diff (enforced in CI)
+just demo       # run the demo pipeline
+```
+
+## Pull requests
+
+- Keep PRs small and focused.
+- Use conventional commit titles: `type(scope): Imperative subject`
+  (e.g. `fix(core): Strip context cancellation during event emission`).
+- Add tests for behaviour changes; event-sequence assertions preferred.

--- a/Justfile
+++ b/Justfile
@@ -35,6 +35,17 @@ tidy:
 check-clean: fmt tidy
     git diff --exit-code
 
+# Build all example modules (they are not covered by `test`)
+build-examples:
+    for dir in examples/*/; do \
+        (cd $dir && go build ./...); \
+    done
+
+# Point submodules at the version about to be released. Run before tagging.
+# go.sum entries for the new version land via `just tidy` once the tag exists.
+prepare-release version:
+    cd observers/terminal && go mod edit -require=github.com/ruffel/pipeline@{{ version }}
+
 # Run the demo (formats: terminal, plain, json)
 demo format="terminal":
     cd examples/demo && go run . -format {{ format }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+Report vulnerabilities privately via
+[GitHub security advisories](https://github.com/ruffel/pipeline/security/advisories/new).
+Please do not open public issues for security reports.
+
+Only the latest release receives security fixes.


### PR DESCRIPTION
CI previously linted only the root module (`./...` doesn't cross module boundaries, even in workspace mode) and never compiled the examples.

- Lint `observers/terminal` with the workspace on, so it typechecks against HEAD core
- `just build-examples` recipe + CI step so API changes can't silently break README-linked code
- Release workflow now fails if a submodule's core require doesn't match the tag (pairs with #70); `just prepare-release <version>` does the bump
- Add govulncheck job, SECURITY.md, CONTRIBUTING.md