### PR TITLE
fix(core): Observe context cancellation between sequential steps

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -104,6 +104,12 @@ func (e *Executor) runStage(ctx context.Context, loc Location, s Stage) error {
 
 func (e *Executor) runStepsSequential(ctx context.Context, loc Location, s Stage) error {
 	for _, step := range s.Steps {
+		// Mirror the between-stages check: once the run context is cancelled,
+		// remaining steps must not start.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		if err := e.runStep(e.stepCtx(ctx, loc, step), loc.WithStep(step.Name), step); err != nil {
 			if errors.Is(err, ErrSkipStage) {
 				return nil

--- a/executor_test.go
+++ b/executor_test.go
@@ -412,6 +412,56 @@ func TestExecutor_ContextCancelled(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestExecutor_ContextCancelledBetweenSequentialSteps(t *testing.T) {
+	t.Parallel()
+
+	obs := &recordingObserver{}
+	ex := pipeline.NewExecutor(obs)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var secondRan atomic.Bool
+
+	err := ex.Run(ctx, pipeline.Pipeline{
+		Name: "deploy",
+		Stages: []pipeline.Stage{
+			{
+				Name: "build",
+				Steps: []pipeline.Step{
+					{
+						Name: "cancels-run",
+						Run: func(_ context.Context) error {
+							cancel()
+
+							return nil
+						},
+					},
+					{
+						Name: "never-runs",
+						Run: func(_ context.Context) error {
+							secondRan.Store(true)
+
+							return nil
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, secondRan.Load(), "steps after cancellation should not run")
+
+	assert.Equal(t, []string{
+		"pipeline.PipelineStartedEvent",
+		"pipeline.StageStartedEvent",
+		"pipeline.StepStartedEvent",
+		"pipeline.StepPassedEvent",
+		"pipeline.StageFailedEvent",
+		"pipeline.PipelineFailedEvent",
+	}, obs.eventTypes())
+}
+
 type ctxRecordingObserver struct {
 	mu           sync.Mutex
 	events       []pipeline.Event


### PR DESCRIPTION
The executor checked `ctx.Err()` between stages but not between steps, so after cancellation every remaining step in the current stage still ran unless the step honoured ctx itself. The stage now fails with the context error, mirroring the between-stages behaviour.