### PR TITLE
feat(core): Add MaxParallel limit for parallel stages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -28,6 +28,22 @@ observer would often see a cancelled context exactly when that final state was
 most important. Non-terminal events keep the original cancellation state so
 observers can still tell whether they were emitted before or after cancellation.
 
+## Skip Events for Bypassed Steps
+
+**Decision:** When a step ends a sequential stage via `ErrSkipStage`, every
+bypassed step emits a `StepSkippedEvent`. Work bypassed by `ErrSkipPipeline`
+(remaining steps and stages) emits nothing.
+
+`PipelineStartedEvent` carries the full definition precisely so observers can
+pre-render the plan. A step that silently never runs leaves such UIs with an
+unresolved entry, so bypassed steps are accounted for individually.
+
+`ErrSkipPipeline` is intentionally asymmetric: it means "the pipeline is done,
+successfully" — the run has reached its conclusion early, and the remaining
+stages are not skipped work that needs accounting. A cascade of stage and step
+skip events would bury that signal in noise. Observers that need to show
+unvisited stages can diff the definition against the events received.
+
 ## Panic Recovery
 
 **Decision:** The executor recovers panics during `Step.Run`, but does NOT recover panics in observers or executor scaffolding.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ ex.Run(context.Background(), p)
 ## Features
 
 - **Sequential & parallel stages** — `NewStage` runs steps in order, `NewParallelStage` runs concurrently
+- **Bounded parallelism** — `WithMaxParallel(n)` caps how many steps of a parallel stage run at once
 - **Conditions** — skip stages or steps based on runtime checks
 - **Retry & timeout** — `WithRetry(3, time.Second, fn)`, `WithTimeout(30*time.Second, fn)`
 - **Flow control** — `ErrSkipStage` and `ErrSkipPipeline` for early exit without failure

--- a/builder.go
+++ b/builder.go
@@ -42,6 +42,14 @@ func (s Stage) WithContinueOnError(continueOnError bool) Stage {
 	return s
 }
 
+// WithMaxParallel caps the number of steps running concurrently in a parallel
+// stage. Zero means unlimited. Only valid on parallel stages.
+func (s Stage) WithMaxParallel(n int) Stage {
+	s.MaxParallel = n
+
+	return s
+}
+
 // NewStep creates a [Step] with the given name and run function.
 func NewStep(name string, run StepFn) Step {
 	return Step{

--- a/builder_test.go
+++ b/builder_test.go
@@ -24,7 +24,7 @@ func TestBuilders(t *testing.T) {
 		pipeline.NewParallelStage("build",
 			pipeline.NewStep("api", runFast),
 			pipeline.NewStep("worker", runSlow).WithCondition(skipCond),
-		).WithContinueOnError(true),
+		).WithContinueOnError(true).WithMaxParallel(2),
 	)
 
 	assert.Equal(t, "deploy", p.Name)
@@ -42,6 +42,7 @@ func TestBuilders(t *testing.T) {
 	assert.Equal(t, "build", s2.Name)
 	assert.True(t, s2.Parallel)
 	assert.True(t, s2.ContinueOnError)
+	assert.Equal(t, 2, s2.MaxParallel)
 	assert.Nil(t, s2.Condition)
 	assert.Len(t, s2.Steps, 2)
 

--- a/executor.go
+++ b/executor.go
@@ -103,7 +103,7 @@ func (e *Executor) runStage(ctx context.Context, loc Location, s Stage) error {
 }
 
 func (e *Executor) runStepsSequential(ctx context.Context, loc Location, s Stage) error {
-	for _, step := range s.Steps {
+	for i, step := range s.Steps {
 		// Mirror the between-stages check: once the run context is cancelled,
 		// remaining steps must not start.
 		if err := ctx.Err(); err != nil {
@@ -112,6 +112,8 @@ func (e *Executor) runStepsSequential(ctx context.Context, loc Location, s Stage
 
 		if err := e.runStep(e.stepCtx(ctx, loc, step), loc.WithStep(step.Name), step); err != nil {
 			if errors.Is(err, ErrSkipStage) {
+				e.emitBypassedSteps(ctx, loc, s.Steps[i+1:], step.Name)
+
 				return nil
 			}
 
@@ -120,6 +122,17 @@ func (e *Executor) runStepsSequential(ctx context.Context, loc Location, s Stage
 	}
 
 	return nil
+}
+
+// emitBypassedSteps emits a [StepSkippedEvent] for each step bypassed when an
+// earlier step ends its stage via [ErrSkipStage], so observers that pre-render
+// the pipeline definition can resolve every step.
+func (e *Executor) emitBypassedSteps(ctx context.Context, loc Location, steps []Step, cause string) {
+	reason := fmt.Sprintf("%q ended the stage early", cause)
+
+	for _, step := range steps {
+		e.emit(ctx, newStepSkippedEvent(loc.WithStep(step.Name), reason, time.Now()))
+	}
 }
 
 func (e *Executor) runStepsParallel(ctx context.Context, loc Location, s Stage) error {

--- a/executor.go
+++ b/executor.go
@@ -104,6 +104,12 @@ func (e *Executor) runStage(ctx context.Context, loc Location, s Stage) error {
 
 func (e *Executor) runStepsSequential(ctx context.Context, loc Location, s Stage) error {
 	for _, step := range s.Steps {
+		// Mirror the between-stages check: once the run context is cancelled,
+		// remaining steps must not start.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		if err := e.runStep(e.stepCtx(ctx, loc, step), loc.WithStep(step.Name), step); err != nil {
 			if errors.Is(err, ErrSkipStage) {
 				return nil

--- a/executor.go
+++ b/executor.go
@@ -146,6 +146,10 @@ func (e *Executor) runStepsParallel(ctx context.Context, loc Location, s Stage) 
 func (e *Executor) runStepsFailFast(ctx context.Context, loc Location, s Stage) error {
 	g, gctx := errgroup.WithContext(ctx)
 
+	if s.MaxParallel > 0 {
+		g.SetLimit(s.MaxParallel)
+	}
+
 	var (
 		mu           sync.Mutex
 		skipPipeline bool
@@ -197,6 +201,12 @@ func (e *Executor) runStepsBestEffort(ctx context.Context, loc Location, s Stage
 		skipPipeline bool
 	)
 
+	// Optional counting semaphore bounding concurrent steps.
+	var sem chan struct{}
+	if s.MaxParallel > 0 {
+		sem = make(chan struct{}, s.MaxParallel)
+	}
+
 	for _, step := range s.Steps {
 		wg.Add(1)
 
@@ -205,6 +215,12 @@ func (e *Executor) runStepsBestEffort(ctx context.Context, loc Location, s Stage
 
 		go func() {
 			defer wg.Done()
+
+			if sem != nil {
+				sem <- struct{}{}
+
+				defer func() { <-sem }()
+			}
 
 			if err := e.runStep(stepCtx, stepLoc, step); err != nil {
 				mu.Lock()
@@ -332,31 +348,47 @@ func (e *Executor) validate(p Pipeline) error {
 			stageNames[s.Name] = true
 		}
 
-		if len(s.Steps) == 0 {
-			errs = append(errs, fmt.Errorf("stage[%d] %q: must have at least one step", i, s.Name))
-		}
-
-		if s.ContinueOnError && !s.Parallel {
-			errs = append(errs, fmt.Errorf("stage[%d] %q: ContinueOnError requires Parallel", i, s.Name))
-		}
-
-		stepNames := make(map[string]bool, len(s.Steps))
-
-		for j, t := range s.Steps {
-			switch {
-			case t.Name == "":
-				errs = append(errs, fmt.Errorf("stage[%d] step[%d]: name cannot be empty", i, j))
-			case stepNames[t.Name]:
-				errs = append(errs, fmt.Errorf("stage[%d] step[%d]: duplicate step name %q", i, j, t.Name))
-			default:
-				stepNames[t.Name] = true
-			}
-
-			if t.Run == nil {
-				errs = append(errs, fmt.Errorf("stage[%d] step[%d] %q: run function cannot be nil", i, j, t.Name))
-			}
-		}
+		errs = append(errs, validateStage(i, s)...)
 	}
 
 	return errors.Join(errs...)
+}
+
+func validateStage(i int, s Stage) []error {
+	var errs []error
+
+	if len(s.Steps) == 0 {
+		errs = append(errs, fmt.Errorf("stage[%d] %q: must have at least one step", i, s.Name))
+	}
+
+	if s.ContinueOnError && !s.Parallel {
+		errs = append(errs, fmt.Errorf("stage[%d] %q: ContinueOnError requires Parallel", i, s.Name))
+	}
+
+	if s.MaxParallel < 0 {
+		errs = append(errs, fmt.Errorf("stage[%d] %q: MaxParallel cannot be negative", i, s.Name))
+	}
+
+	if s.MaxParallel > 0 && !s.Parallel {
+		errs = append(errs, fmt.Errorf("stage[%d] %q: MaxParallel requires Parallel", i, s.Name))
+	}
+
+	stepNames := make(map[string]bool, len(s.Steps))
+
+	for j, t := range s.Steps {
+		switch {
+		case t.Name == "":
+			errs = append(errs, fmt.Errorf("stage[%d] step[%d]: name cannot be empty", i, j))
+		case stepNames[t.Name]:
+			errs = append(errs, fmt.Errorf("stage[%d] step[%d]: duplicate step name %q", i, j, t.Name))
+		default:
+			stepNames[t.Name] = true
+		}
+
+		if t.Run == nil {
+			errs = append(errs, fmt.Errorf("stage[%d] step[%d] %q: run function cannot be nil", i, j, t.Name))
+		}
+	}
+
+	return errs
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -867,6 +867,71 @@ func TestExecutor_ContinueOnError_SkipStageAbsorbed(t *testing.T) {
 // Emitter wiring
 // -----------------------------------------------------------------------------
 
+// concurrencyGauge returns a step that tracks the peak number of concurrently
+// running invocations in peak.
+func concurrencyGauge(current, peak *atomic.Int32) pipeline.StepFn {
+	return func(_ context.Context) error {
+		c := current.Add(1)
+
+		for {
+			p := peak.Load()
+			if c <= p || peak.CompareAndSwap(p, c) {
+				break
+			}
+		}
+
+		time.Sleep(20 * time.Millisecond)
+		current.Add(-1)
+
+		return nil
+	}
+}
+
+func TestExecutor_MaxParallel_LimitsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	modes := []struct {
+		name            string
+		continueOnError bool
+	}{
+		{name: "fail fast", continueOnError: false},
+		{name: "continue on error", continueOnError: true},
+	}
+
+	for _, tt := range modes {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const (
+				limit     = 2
+				stepCount = 6
+			)
+
+			var current, peak atomic.Int32
+
+			steps := make([]pipeline.Step, stepCount)
+			for i := range steps {
+				steps[i] = pipeline.Step{Name: fmt.Sprintf("step-%d", i), Run: concurrencyGauge(&current, &peak)}
+			}
+
+			err := pipeline.NewExecutor().Run(t.Context(), pipeline.Pipeline{
+				Name: "p",
+				Stages: []pipeline.Stage{{
+					Name:            "fan-out",
+					Parallel:        true,
+					ContinueOnError: tt.continueOnError,
+					MaxParallel:     limit,
+					Steps:           steps,
+				}},
+			})
+			require.NoError(t, err)
+
+			assert.LessOrEqual(t, peak.Load(), int32(limit))
+			assert.Zero(t, current.Load())
+		})
+	}
+}
+
 func TestExecutor_EmitterInStepContext(t *testing.T) {
 	t.Parallel()
 
@@ -1024,6 +1089,26 @@ func TestExecutor_Validation(t *testing.T) {
 				},
 			},
 			wantErr: "ContinueOnError requires Parallel",
+		},
+		{
+			name: "negative MaxParallel",
+			p: pipeline.Pipeline{
+				Name: "p",
+				Stages: []pipeline.Stage{
+					{Name: "s", Parallel: true, MaxParallel: -1, Steps: []pipeline.Step{{Name: "a", Run: noop}}},
+				},
+			},
+			wantErr: "MaxParallel cannot be negative",
+		},
+		{
+			name: "MaxParallel requires Parallel",
+			p: pipeline.Pipeline{
+				Name: "p",
+				Stages: []pipeline.Stage{
+					{Name: "s", MaxParallel: 2, Steps: []pipeline.Step{{Name: "a", Run: noop}}},
+				},
+			},
+			wantErr: "MaxParallel requires Parallel",
 		},
 	}
 

--- a/executor_test.go
+++ b/executor_test.go
@@ -412,6 +412,56 @@ func TestExecutor_ContextCancelled(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestExecutor_ContextCancelledBetweenSequentialSteps(t *testing.T) {
+	t.Parallel()
+
+	obs := &recordingObserver{}
+	ex := pipeline.NewExecutor(obs)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var secondRan atomic.Bool
+
+	err := ex.Run(ctx, pipeline.Pipeline{
+		Name: "deploy",
+		Stages: []pipeline.Stage{
+			{
+				Name: "build",
+				Steps: []pipeline.Step{
+					{
+						Name: "cancels-run",
+						Run: func(_ context.Context) error {
+							cancel()
+
+							return nil
+						},
+					},
+					{
+						Name: "never-runs",
+						Run: func(_ context.Context) error {
+							secondRan.Store(true)
+
+							return nil
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, secondRan.Load(), "steps after cancellation should not run")
+
+	assert.Equal(t, []string{
+		"pipeline.PipelineStartedEvent",
+		"pipeline.StageStartedEvent",
+		"pipeline.StepStartedEvent",
+		"pipeline.StepPassedEvent",
+		"pipeline.StageFailedEvent",
+		"pipeline.PipelineFailedEvent",
+	}, obs.eventTypes())
+}
+
 type ctxRecordingObserver struct {
 	mu           sync.Mutex
 	events       []pipeline.Event

--- a/executor_test.go
+++ b/executor_test.go
@@ -250,12 +250,35 @@ func TestExecutor_ErrSkipStage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Sentinel returns produce StepPassedEvent — the step ran and resolved.
-	types := obs.eventTypes()
-	assert.NotContains(t, types, "pipeline.StepSkippedEvent")
-	assert.NotContains(t, types, "pipeline.StepFailedEvent")
-	assert.NotContains(t, types, "pipeline.StageFailedEvent")
-	assert.Contains(t, types, "pipeline.PipelinePassedEvent")
+	// The sentinel step passes (it ran and resolved); bypassed steps are
+	// accounted for with skip events.
+	assert.Equal(t, []string{
+		"pipeline.PipelineStartedEvent",
+		"pipeline.StageStartedEvent",
+		"pipeline.StepStartedEvent",
+		"pipeline.StepPassedEvent",
+		"pipeline.StepStartedEvent",
+		"pipeline.StepPassedEvent",
+		"pipeline.StepSkippedEvent",
+		"pipeline.StagePassedEvent",
+		"pipeline.StageStartedEvent",
+		"pipeline.StepStartedEvent",
+		"pipeline.StepPassedEvent",
+		"pipeline.StagePassedEvent",
+		"pipeline.PipelinePassedEvent",
+	}, obs.eventTypes())
+
+	var skipped []pipeline.StepSkippedEvent
+
+	for _, e := range obs.events {
+		if s, ok := e.(pipeline.StepSkippedEvent); ok {
+			skipped = append(skipped, s)
+		}
+	}
+
+	require.Len(t, skipped, 1)
+	assert.Equal(t, "should-not-run", skipped[0].Step)
+	assert.Equal(t, `"skip-rest" ended the stage early`, skipped[0].Reason)
 }
 
 func TestExecutor_StepReturnsNilEarly(t *testing.T) {

--- a/pipeline.go
+++ b/pipeline.go
@@ -25,6 +25,7 @@ type Stage struct {
 	Steps           []Step      // The steps that make up the stage.
 	Parallel        bool        // When true, steps run concurrently.
 	ContinueOnError bool        // When true, all steps run even if some fail; errors are joined.
+	MaxParallel     int         // Caps concurrently running steps in a parallel stage; 0 = unlimited.
 	Condition       ConditionFn // Optional; non-empty return skips the stage with that reason.
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -48,6 +48,8 @@ var (
 
 	// ErrSkipStage causes the executor to skip the remaining steps in the
 	// current stage and continue with the next stage. The stage emits a
-	// [StagePassedEvent].
+	// [StagePassedEvent]. In a sequential stage, each bypassed step emits a
+	// [StepSkippedEvent]; in a parallel stage every step has already started,
+	// so nothing is bypassed.
 	ErrSkipStage = errors.New("skip stage")
 )


### PR DESCRIPTION
`Stage.MaxParallel` / `WithMaxParallel(n)` caps how many steps of a parallel stage run at once (0 = unlimited): `errgroup.SetLimit` in fail-fast mode, a counting semaphore in continue-on-error mode. Validated like `ContinueOnError` (requires `Parallel`, must be non-negative).

Stacked on #73.