### PR TITLE
feat(core): Add Description to Stage and Step

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -34,6 +34,14 @@ func (s Stage) WithCondition(cond ConditionFn) Stage {
 	return s
 }
 
+// WithDescription sets a human-readable summary that observers may display
+// alongside the stage name.
+func (s Stage) WithDescription(d string) Stage {
+	s.Description = d
+
+	return s
+}
+
 // WithContinueOnError sets whether parallel execution should continue if a
 // step fails. Has no effect on sequential stages.
 func (s Stage) WithContinueOnError(continueOnError bool) Stage {
@@ -53,6 +61,14 @@ func NewStep(name string, run StepFn) Step {
 // WithCondition sets the conditional execution function for the step.
 func (s Step) WithCondition(cond ConditionFn) Step {
 	s.Condition = cond
+
+	return s
+}
+
+// WithDescription sets a human-readable summary that observers may display
+// alongside the step name.
+func (s Step) WithDescription(d string) Step {
+	s.Description = d
 
 	return s
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -18,8 +18,8 @@ func TestBuilders(t *testing.T) {
 
 	p := pipeline.NewPipeline("deploy",
 		pipeline.NewStage("preflight",
-			pipeline.NewStep("check", runFast),
-		).WithCondition(skipCond),
+			pipeline.NewStep("check", runFast).WithDescription("Verifies cluster access"),
+		).WithCondition(skipCond).WithDescription("Sanity checks"),
 
 		pipeline.NewParallelStage("build",
 			pipeline.NewStep("api", runFast),
@@ -33,9 +33,11 @@ func TestBuilders(t *testing.T) {
 	// Stage 1: preflight
 	s1 := p.Stages[0]
 	assert.Equal(t, "preflight", s1.Name)
+	assert.Equal(t, "Sanity checks", s1.Description)
 	assert.False(t, s1.Parallel)
 	assert.NotNil(t, s1.Condition)
 	assert.Len(t, s1.Steps, 1)
+	assert.Equal(t, "Verifies cluster access", s1.Steps[0].Description)
 
 	// Stage 2: build
 	s2 := p.Stages[1]

--- a/observers/json/observer.go
+++ b/observers/json/observer.go
@@ -30,13 +30,18 @@ type Observer struct {
 
 	// starts tracks event timestamps for duration calculation.
 	starts map[pipeline.Location]time.Time
+
+	// descriptions holds stage/step descriptions captured from the pipeline
+	// definition, keyed by location.
+	descriptions map[pipeline.Location]string
 }
 
 // New creates a JSON observer that writes to w.
 func New(w io.Writer) *Observer {
 	return &Observer{
-		enc:    json.NewEncoder(w),
-		starts: make(map[pipeline.Location]time.Time),
+		enc:          json.NewEncoder(w),
+		starts:       make(map[pipeline.Location]time.Time),
+		descriptions: make(map[pipeline.Location]string),
 	}
 }
 
@@ -46,6 +51,7 @@ func (o *Observer) OnEvent(_ context.Context, event pipeline.Event) { //nolint:c
 	case pipeline.PipelineStartedEvent:
 		clear(o.starts)
 		o.err = nil
+		o.captureDescriptions(e.Definition)
 		o.starts[e.Location] = e.Timestamp
 		o.write("PipelineStarted", e.Location, e.Timestamp, 0, nil)
 
@@ -59,7 +65,7 @@ func (o *Observer) OnEvent(_ context.Context, event pipeline.Event) { //nolint:c
 
 	case pipeline.StageStartedEvent:
 		o.starts[e.Location] = e.Timestamp
-		o.write("StageStarted", e.Location, e.Timestamp, 0, nil)
+		o.write("StageStarted", e.Location, e.Timestamp, 0, o.descriptionFields(e.Location))
 
 	case pipeline.StagePassedEvent:
 		o.write("StagePassed", e.Location, e.Timestamp, o.duration(e.Location, e.Timestamp), nil)
@@ -76,7 +82,7 @@ func (o *Observer) OnEvent(_ context.Context, event pipeline.Event) { //nolint:c
 
 	case pipeline.StepStartedEvent:
 		o.starts[e.Location] = e.Timestamp
-		o.write("StepStarted", e.Location, e.Timestamp, 0, nil)
+		o.write("StepStarted", e.Location, e.Timestamp, 0, o.descriptionFields(e.Location))
 
 	case pipeline.StepPassedEvent:
 		o.write("StepPassed", e.Location, e.Timestamp, o.duration(e.Location, e.Timestamp), nil)
@@ -189,6 +195,37 @@ func (o *Observer) write(typ string, loc pipeline.Location, ts time.Time, dur ti
 		DurationMs: dur.Milliseconds(),
 		Extra:      extra,
 	})
+}
+
+// captureDescriptions records the stage/step descriptions declared in the
+// pipeline definition so Started events can carry them.
+func (o *Observer) captureDescriptions(def pipeline.Pipeline) {
+	clear(o.descriptions)
+
+	for _, stage := range def.Stages {
+		loc := pipeline.Location{Pipeline: def.Name, Stage: stage.Name}
+
+		if stage.Description != "" {
+			o.descriptions[loc] = stage.Description
+		}
+
+		for _, step := range stage.Steps {
+			if step.Description != "" {
+				o.descriptions[loc.WithStep(step.Name)] = step.Description
+			}
+		}
+	}
+}
+
+// descriptionFields returns a "description" field for the location, or nil
+// when the definition declared none.
+func (o *Observer) descriptionFields(loc pipeline.Location) fields {
+	desc, ok := o.descriptions[loc]
+	if !ok {
+		return nil
+	}
+
+	return fields{"description": desc}
 }
 
 func (o *Observer) duration(loc pipeline.Location, now time.Time) time.Duration {

--- a/observers/json/observer_test.go
+++ b/observers/json/observer_test.go
@@ -55,6 +55,51 @@ func TestObserver_HappyPath(t *testing.T) {
 	}, types)
 }
 
+func TestObserver_Descriptions(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	obs := jsonobs.New(&buf)
+	ctx := t.Context()
+
+	def := pipeline.NewPipeline("deploy",
+		pipeline.NewStage("build",
+			pipeline.NewStep("compile", nil).WithDescription("Compiles the service"),
+		).WithDescription("Produces artifacts"),
+	)
+
+	events := []pipeline.Event{
+		pipeline.PipelineStartedEvent{BaseEvent: base("deploy", "", "", fixedTime), Definition: def},
+		pipeline.StageStartedEvent{BaseEvent: base("deploy", "build", "", fixedTime)},
+		pipeline.StepStartedEvent{BaseEvent: base("deploy", "build", "compile", fixedTime)},
+		pipeline.StepPassedEvent{BaseEvent: base("deploy", "build", "compile", fixedTime)},
+	}
+
+	for _, e := range events {
+		obs.OnEvent(ctx, e)
+	}
+
+	lines := nonEmptyLines(buf.String())
+	require.Len(t, lines, 4)
+
+	var stage map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &stage))
+	assert.Equal(t, "Produces artifacts", stage["description"])
+
+	var step map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(lines[2]), &step))
+	assert.Equal(t, "Compiles the service", step["description"])
+
+	// Only start events carry the description.
+	var passed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(lines[3]), &passed))
+	assert.NotContains(t, passed, "description")
+}
+
 func TestObserver_TypeDiscriminator(t *testing.T) {
 	t.Parallel()
 

--- a/observers/plain/observer.go
+++ b/observers/plain/observer.go
@@ -27,13 +27,18 @@ type Observer struct {
 
 	// starts tracks event timestamps for duration calculation.
 	starts map[pipeline.Location]time.Time
+
+	// descriptions holds stage/step descriptions captured from the pipeline
+	// definition, keyed by location.
+	descriptions map[pipeline.Location]string
 }
 
 // New creates a terminal observer that writes to w.
 func New(w io.Writer) *Observer {
 	return &Observer{
-		w:      w,
-		starts: make(map[pipeline.Location]time.Time),
+		w:            w,
+		starts:       make(map[pipeline.Location]time.Time),
+		descriptions: make(map[pipeline.Location]string),
 	}
 }
 
@@ -47,6 +52,7 @@ func (o *Observer) OnEvent(_ context.Context, event pipeline.Event) {
 	// -------------------------------------------------------------------------
 	case pipeline.PipelineStartedEvent:
 		clear(o.starts)
+		o.captureDescriptions(e.Definition)
 		o.starts[e.Location] = e.Timestamp
 		o.writef("▶ Pipeline: %s\n", e.Pipeline)
 
@@ -61,7 +67,7 @@ func (o *Observer) OnEvent(_ context.Context, event pipeline.Event) {
 	// -------------------------------------------------------------------------
 	case pipeline.StageStartedEvent:
 		o.starts[e.Location] = e.Timestamp
-		o.writef("  ▶ Stage: %s\n", e.Stage)
+		o.writef("  ▶ Stage: %s%s\n", e.Stage, o.description(e.Location))
 
 	case pipeline.StagePassedEvent:
 		o.writef("  ✓ Stage: %s%s\n", e.Stage, o.elapsed(e.Location, e.Timestamp))
@@ -77,6 +83,10 @@ func (o *Observer) OnEvent(_ context.Context, event pipeline.Event) {
 	// -------------------------------------------------------------------------
 	case pipeline.StepStartedEvent:
 		o.starts[e.Location] = e.Timestamp
+
+		if desc := o.description(e.Location); desc != "" {
+			o.writef("    · %s%s\n", e.Step, desc)
+		}
 
 	case pipeline.StepPassedEvent:
 		o.writef("    ✓ %s%s\n", e.Step, o.elapsed(e.Location, e.Timestamp))
@@ -110,6 +120,37 @@ func (o *Observer) OnEvent(_ context.Context, event pipeline.Event) {
 
 func (o *Observer) writef(format string, args ...any) {
 	_, _ = fmt.Fprintf(o.w, format, args...)
+}
+
+// captureDescriptions records the stage/step descriptions declared in the
+// pipeline definition so start events can carry them.
+func (o *Observer) captureDescriptions(def pipeline.Pipeline) {
+	clear(o.descriptions)
+
+	for _, stage := range def.Stages {
+		loc := pipeline.Location{Pipeline: def.Name, Stage: stage.Name}
+
+		if stage.Description != "" {
+			o.descriptions[loc] = stage.Description
+		}
+
+		for _, step := range stage.Steps {
+			if step.Description != "" {
+				o.descriptions[loc.WithStep(step.Name)] = step.Description
+			}
+		}
+	}
+}
+
+// description returns " — <description>" for the location, or empty when the
+// definition declared none.
+func (o *Observer) description(loc pipeline.Location) string {
+	desc, ok := o.descriptions[loc]
+	if !ok {
+		return ""
+	}
+
+	return " — " + desc
 }
 
 func (o *Observer) elapsed(loc pipeline.Location, now time.Time) string {

--- a/observers/plain/observer_test.go
+++ b/observers/plain/observer_test.go
@@ -45,6 +45,35 @@ func TestObserver_HappyPath(t *testing.T) {
 	assert.Contains(t, output, "✓ Pipeline: deploy (1s)")
 }
 
+func TestObserver_Descriptions(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	obs := plain.New(&buf)
+	ctx := t.Context()
+
+	def := pipeline.NewPipeline("deploy",
+		pipeline.NewStage("build",
+			pipeline.NewStep("compile", nil).WithDescription("Compiles the service"),
+		).WithDescription("Produces artifacts"),
+	)
+
+	events := []pipeline.Event{
+		pipeline.PipelineStartedEvent{BaseEvent: base("deploy", "", "", fixedTime), Definition: def},
+		pipeline.StageStartedEvent{BaseEvent: base("deploy", "build", "", fixedTime)},
+		pipeline.StepStartedEvent{BaseEvent: base("deploy", "build", "compile", fixedTime)},
+	}
+
+	for _, e := range events {
+		obs.OnEvent(ctx, e)
+	}
+
+	output := buf.String()
+	assert.Contains(t, output, "▶ Stage: build — Produces artifacts")
+	assert.Contains(t, output, "· compile — Compiles the service")
+}
+
 func TestObserver_StepFailure(t *testing.T) {
 	t.Parallel()
 

--- a/observers/terminal/observer.go
+++ b/observers/terminal/observer.go
@@ -80,6 +80,7 @@ func (o *Observer) OnEvent(ctx context.Context, ev pipeline.Event) {
 
 	case pipeline.StepStartedEvent:
 		o.state.stepTimes[e.Location] = e.Timestamp
+		output = o.opts.FormatStepStart(ctx, e, o.state, o.opts.Palette)
 
 	case pipeline.StepPassedEvent:
 		dur := e.Timestamp.Sub(o.state.stepTimes[e.Location])

--- a/observers/terminal/observer_test.go
+++ b/observers/terminal/observer_test.go
@@ -100,6 +100,29 @@ func TestObserver_SameStepNameInDifferentStages(t *testing.T) {
 	assert.Contains(t, out, "✓ validate (")
 }
 
+func TestObserver_Descriptions(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	obs := termobs.New(&buf)
+	ex := pipeline.NewExecutor(obs)
+
+	p := pipeline.NewPipeline("deploy",
+		pipeline.NewStage("build",
+			pipeline.NewStep("compile", func(_ context.Context) error { return nil }).
+				WithDescription("Compiles the service"),
+		).WithDescription("Produces artifacts"),
+	)
+
+	require.NoError(t, ex.Run(t.Context(), p))
+
+	out := buf.String()
+
+	assert.Contains(t, out, "Produces artifacts")
+	assert.Contains(t, out, "Compiles the service")
+}
+
 func TestObserver_CustomEvent_DefaultNoOp(t *testing.T) {
 	t.Parallel()
 

--- a/observers/terminal/options.go
+++ b/observers/terminal/options.go
@@ -47,6 +47,10 @@ type State struct {
 	// used for left-column alignment in parallel stages.
 	MaxStepLen int
 
+	// Descriptions maps stage and step locations to the optional
+	// descriptions declared in the pipeline definition.
+	Descriptions map[pipeline.Location]string
+
 	// FailedSteps tracks failed step descriptions for the end-of-pipeline summary.
 	FailedSteps []string
 
@@ -64,6 +68,7 @@ type State struct {
 func newState(def pipeline.Pipeline) State {
 	s := State{
 		StageParallel: make(map[string]bool, len(def.Stages)),
+		Descriptions:  make(map[pipeline.Location]string),
 		stageTimes:    make(map[string]time.Time),
 		stepTimes:     make(map[pipeline.Location]time.Time),
 	}
@@ -71,7 +76,16 @@ func newState(def pipeline.Pipeline) State {
 	for _, stage := range def.Stages {
 		s.StageParallel[stage.Name] = stage.Parallel
 
+		loc := pipeline.Location{Pipeline: def.Name, Stage: stage.Name}
+		if stage.Description != "" {
+			s.Descriptions[loc] = stage.Description
+		}
+
 		for _, step := range stage.Steps {
+			if step.Description != "" {
+				s.Descriptions[loc.WithStep(step.Name)] = step.Description
+			}
+
 			if len(step.Name) > s.MaxStepLen {
 				s.MaxStepLen = len(step.Name)
 			}
@@ -98,6 +112,7 @@ type Options struct {
 	FormatStagePass     func(ctx context.Context, e pipeline.StagePassedEvent, d time.Duration, s State, p Palette) string
 	FormatStageFail     func(ctx context.Context, e pipeline.StageFailedEvent, d time.Duration, s State, p Palette) string
 	FormatStageSkip     func(ctx context.Context, e pipeline.StageSkippedEvent, s State, p Palette) string
+	FormatStepStart     func(ctx context.Context, e pipeline.StepStartedEvent, s State, p Palette) string
 	FormatStepPass      func(ctx context.Context, e pipeline.StepPassedEvent, d time.Duration, s State, p Palette) string
 	FormatStepFail      func(ctx context.Context, e pipeline.StepFailedEvent, d time.Duration, s State, p Palette) string
 	FormatStepSkip      func(ctx context.Context, e pipeline.StepSkippedEvent, s State, p Palette) string
@@ -136,6 +151,10 @@ func (o *Options) applyDefaults() {
 
 	if o.FormatStageSkip == nil {
 		o.FormatStageSkip = defaults.FormatStageSkip
+	}
+
+	if o.FormatStepStart == nil {
+		o.FormatStepStart = defaults.FormatStepStart
 	}
 
 	if o.FormatStepPass == nil {

--- a/observers/terminal/styles.go
+++ b/observers/terminal/styles.go
@@ -43,6 +43,7 @@ func DefaultOptions() Options {
 		FormatStagePass:     formatStagePass,
 		FormatStageFail:     formatStageFail,
 		FormatStageSkip:     formatStageSkip,
+		FormatStepStart:     formatStepStart,
 		FormatStepPass:      formatStepPass,
 		FormatStepFail:      formatStepFail,
 		FormatStepSkip:      formatStepSkip,
@@ -164,13 +165,19 @@ func formatPipelineEnd(_ context.Context, e pipeline.Event, duration time.Durati
 	))
 }
 
-func formatStageStart(_ context.Context, e pipeline.StageStartedEvent, _ State, p Palette) string {
+func formatStageStart(_ context.Context, e pipeline.StageStartedEvent, s State, p Palette) string {
 	border := lipgloss.NewStyle().
 		BorderBottom(true).BorderTop(true).
 		BorderForeground(p.Primary).BorderStyle(lipgloss.RoundedBorder()).
 		Padding(0, 1)
 
-	return border.Render("Stage: " + e.Stage)
+	title := "Stage: " + e.Stage
+	if desc := s.Descriptions[e.Location]; desc != "" {
+		r := render{p: p}
+		title += "\n" + r.muted(desc)
+	}
+
+	return border.Render(title)
 }
 
 // formatStagePass is a no-op — step-level results already show the outcome.
@@ -188,6 +195,22 @@ func formatStageSkip(_ context.Context, e pipeline.StageSkippedEvent, _ State, p
 	icon := r.muted(p.SkipIcon)
 
 	return fmt.Sprintf("%s Stage: %s — %s", icon, e.Stage, r.muted(e.Reason))
+}
+
+// formatStepStart renders the step's description, if any, as the step begins.
+func formatStepStart(_ context.Context, e pipeline.StepStartedEvent, s State, p Palette) string {
+	desc := s.Descriptions[e.Location]
+	if desc == "" {
+		return ""
+	}
+
+	r := render{p: p, s: s}
+
+	if s.IsParallel(e.Stage, e.Step) {
+		return fmt.Sprintf("%s %s %s", r.prefix(e.Step), r.pipe(), r.muted(desc))
+	}
+
+	return r.muted("· " + desc)
 }
 
 func formatStepPass(_ context.Context, e pipeline.StepPassedEvent, d time.Duration, s State, p Palette) string {

--- a/pipeline.go
+++ b/pipeline.go
@@ -22,6 +22,7 @@ type Pipeline struct {
 // Stage represents a logical grouping of steps within a pipeline.
 type Stage struct {
 	Name            string      // Human-readable display name.
+	Description     string      // Optional; observers may display it alongside the name.
 	Steps           []Step      // The steps that make up the stage.
 	Parallel        bool        // When true, steps run concurrently.
 	ContinueOnError bool        // When true, all steps run even if some fail; errors are joined.
@@ -30,9 +31,10 @@ type Stage struct {
 
 // Step represents a unit of work to be executed within a stage.
 type Step struct {
-	Name      string      // Human-readable display name.
-	Run       StepFn      // The function that performs the step's work.
-	Condition ConditionFn // Optional; non-empty return skips the step with that reason.
+	Name        string      // Human-readable display name.
+	Description string      // Optional; observers may display it alongside the name.
+	Run         StepFn      // The function that performs the step's work.
+	Condition   ConditionFn // Optional; non-empty return skips the step with that reason.
 }
 
 // Sentinel errors for flow control. Steps return these to trigger early exits


### PR DESCRIPTION
Optional `Description` on stages and steps (+ `WithDescription` builders) for runbook-style pipelines where each entry carries operator-facing prose.

- Terminal: new `FormatStepStart` extension point; default renders the description muted under the stage header / at step start
- JSON: `description` field on `StageStarted`/`StepStarted` lines, captured from the definition
- Plain: inline on stage start, single line at step start