### PR TITLE
fix(terminal): Repoint core require at current commit, guard in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,12 @@ jobs:
           args: --timeout=5m
           working-directory: observers/terminal
 
+      # Workspace OFF: proves the submodule builds against the core version its
+      # go.mod actually requires — the way a consumer resolves it. The workspace
+      # would mask a stale require by supplying HEAD core instead.
+      - name: Verify Submodules Build Standalone
+        run: just build-standalone
+
       - name: Verify Clean State
         run: just check-clean
 

--- a/Justfile
+++ b/Justfile
@@ -35,6 +35,24 @@ tidy:
 check-clean: fmt tidy
     git diff --exit-code
 
+# Build submodules with the workspace off, as a consumer resolves them.
+# Fails when a submodule uses core APIs newer than the version it requires —
+# run `just sync-submodules` to repoint them at the current core commit.
+build-standalone:
+    for mod in {{MODULES}}; do \
+        (cd $mod && GOWORK=off go build ./...); \
+    done
+
+# Point submodules at the current origin/main core commit (pseudo-version).
+# Use after landing a core change that a submodule depends on.
+sync-submodules:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    sha="$(git rev-parse origin/main)"
+    for mod in {{MODULES}}; do
+        (cd "$mod" && GOWORK=off go get "github.com/ruffel/pipeline@${sha}")
+    done
+
 # Build all example modules (they are not covered by `test`)
 build-examples:
     for dir in examples/*/; do \

--- a/observers/terminal/go.mod
+++ b/observers/terminal/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/ruffel/pipeline v0.1.4
+	github.com/ruffel/pipeline v0.1.5-0.20260809134210-a3b3c34a82fd
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/observers/terminal/go.sum
+++ b/observers/terminal/go.sum
@@ -25,8 +25,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/ruffel/pipeline v0.1.4 h1:hZbzv6BG9W5avG/yHmRSsvuaQkh0GDTH/sZWA8gIk18=
-github.com/ruffel/pipeline v0.1.4/go.mod h1:HyRGTOcnhM01wXvUs3+T3fgPZPtlNbjz9XHFoEeiFUw=
+github.com/ruffel/pipeline v0.1.5-0.20260809134210-a3b3c34a82fd h1:7YGPftzANb0aiROr7GRpLRTaWB1AWOhsMq7C4OkYark=
+github.com/ruffel/pipeline v0.1.5-0.20260809134210-a3b3c34a82fd/go.mod h1:lTXldStiogM0xMA7z8iu18v+sUrT0VfTkNnDvCRni/8=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
`observers/terminal` stopped compiling standalone on main: #70 pinned it to core `v0.1.4`, then #75 made it read `Stage.Description`, which only exists at HEAD. Reproduce on main with `cd observers/terminal && GOWORK=off go build ./...`.

CI missed it because the terminal lint step runs with the workspace on, which substitutes HEAD core and hides a stale require.

- Require a pseudo-version of the current core commit instead of the last tag
- `just build-standalone` builds submodules with `GOWORK=off` (verified: fails on the stale require, passes after) and now runs in CI
- `just sync-submodules` repoints submodules after landing a core change they depend on

`just prepare-release` still swaps in the real tag at release time.